### PR TITLE
minor deployment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deploy a FastHTML application to [HuggingFace Spaces](https://huggingface.co/spa
 1. Create a free account on [HuggingFace](https://huggingface.co)
 2. Go to your account settings and create an access token with write access. Keep this token safe and don't share it.
 3. Set the `HF_TOKEN` environment variable to that token
-4. Install fasthtml-hf: `pip install fasthtml-hf`
+4. Add `fasthtml-hf` to your requirements.txt and install it: `pip install fasthtml-hf`.
 5. At the top of your `main.py` add `from fasthtml_hf import setup_hf_backup`, and just before you run uvicorn add `setup_hf_backup(app)`
 6. Run `fh_hf_deploy <space_name>`, replacing `<space_name>` with the name you want to give your space.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Deploy a FastHTML application to [HuggingFace Spaces](https://huggingface.co/spa
 1. Create a free account on [HuggingFace](https://huggingface.co)
 2. Go to your account settings and create an access token with write access. Keep this token safe and don't share it.
 3. Set the `HF_TOKEN` environment variable to that token
-4. Add `fasthtml-hf` to your requirements.txt and install it: `pip install fasthtml-hf`.
-5. At the top of your `main.py` add `from fasthtml_hf import setup_hf_backup`, and just before you run uvicorn add `setup_hf_backup(app)`
-6. Run `fh_hf_deploy <space_name>`, replacing `<space_name>` with the name you want to give your space.
+4. Install fasthtml-hf: `pip install fasthtml-hf`
+5. HuggingFace needs `fasthtml-hf` to run your space, so add it to your requirements.txt file.
+6. At the top of your `main.py` add `from fasthtml_hf import setup_hf_backup`, and just before you run uvicorn add `setup_hf_backup(app)`
+7. Run `fh_hf_deploy <space_name>`, replacing `<space_name>` with the name you want to give your space.
 
 By default this will upload a public space. You can make it private with `--private true`.
 

--- a/fasthtml_hf/deploy.py
+++ b/fasthtml_hf/deploy.py
@@ -51,7 +51,7 @@ def deploy(
     token:str=None, # Hugging Face token for authentication
     python_ver:str='3.10', # Version of python to use
     upload:bool_arg=True, # Set to `false` to skip uploading files
-    private:bool_arg=False): # Make the repository private
+    private:lambda x: bool(bool_arg(x))=False): # Make the repository private
     "Upload current directory to Hugging Face Spaces"
     if not token: token=os.getenv('HF_TOKEN')
     if not token: return print('No token available')

--- a/fasthtml_hf/deploy.py
+++ b/fasthtml_hf/deploy.py
@@ -51,13 +51,14 @@ def deploy(
     token:str=None, # Hugging Face token for authentication
     python_ver:str='3.10', # Version of python to use
     upload:bool_arg=True, # Set to `false` to skip uploading files
-    private:lambda x: bool(bool_arg(x))=False): # Make the repository private
+    private:bool_arg=False): # Make the repository private
     "Upload current directory to Hugging Face Spaces"
     if not token: token=os.getenv('HF_TOKEN')
     if not token: return print('No token available')
     if "/" not in space_id: space_id = f"{whoami(token)['name']}/{space_id}"
     _mk_docker(python_ver)
     _mk_README(space_id)
+    private = bool(private) # `private` can be 0,1 or False. As `create_repo` expects private to be True/False we cast it.
     url = create_repo(space_id, token=token, repo_type='space',
                       space_sdk="docker", private=private, exist_ok=True)
     if not upload: return print('Repo created; upload skipped')


### PR DESCRIPTION
This PR implements two minor fixes:
1. When `fh_hf_deploy` is run with `private` set to true/false a 0/1 is passed to `create_repo` which throws `Bad request: "private" must be a boolean.` 
2. `fasthtml-hf` needs to be included in the user's requirements.txt to deploy the app (instruction added to the readme)